### PR TITLE
GCB-135: Deactivate event subscriber

### DIFF
--- a/src/EventSubscriber/Bw2Subscriber.php
+++ b/src/EventSubscriber/Bw2Subscriber.php
@@ -34,7 +34,7 @@ class Bw2Subscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      IqGroupEvents::USER_PROFILE_UPDATE => [['updatebw2Contact', 300]],
+      //IqGroupEvents::USER_PROFILE_UPDATE => [['updatebw2Contact', 300]],
     ];
   }
 


### PR DESCRIPTION
## Issue
BW2 API has been cancelled and need to be removed from the project.
This PR is a first step.

## Change
Deactivate the event listener that send user info to the CRM.